### PR TITLE
[Add] change the cleanup strategy and handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ This setup is useful for asynchronous uploads using Javascripts, particularly wh
    
 If you want to process the form yourself instead after the upload completed, you may define a named route by the name of `lodor_uploaded` like this:
 
-    Route::post('/uploaded')->uses('SomeController@uploaded')->name('lodor_uploaded');
+``` php
+Route::post('/uploaded')->uses('SomeController@uploaded')->name('lodor_uploaded');
+```
 
 If this named route exists, Lodor will automatically redirect the request to the specified controller action instead of returning a JSON response. The controller method should be declared as follows:
 
-```php
+``` php
 <?php
 
 namespace App\Http\Controllers;
@@ -118,12 +120,107 @@ The available options with their corresponding env settings and defaults are:
 | merge_chunks.auto_merge_chunks | LODOR_AUTO_MERGE_CHUNKS      | true            | If set to `true`, _Lodor_ will automatically merge the chunks back to one single file and store it in the `disk_uploads` disk. If set to `false`, the upload process will finish after uploading all chunks to the server. This is useful if you want to re-use the chunks, e.g. for forwarding them to a different server or if you want to implement your own merge algorithm by registering a listener for the `FileUploaded` event.                                                                                                  |
 | merge_chunks.run_async         | LODOR_MERGE_ASYNC            | true            | If set to `true`, the merge process will queue on the `merge_chunks.default_queue` and will wait for the worker to process the job. If you don't want to use worker queues, you can set this to `false` to merge the chunks immediately after uploading. __Warning__: this merges all chunks of an upload immediately after uploading the last chunk. For large chunks or slow transfers, this may exceed the maximum execution time for script execution. You should only set this option to false if you are not concerned about this. |
 | merge_chunks.default_queue     | LODOR_DEFAULT_MERGE_QUEUE    | default         | You may set a different queue name for the merge jobs.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| auto_cleanup                   | LODOR_AUTO_CLEANUP           | false           | Specifies if Lodor should automatically delete the finished upload files after the UploadFinished event is triggered. (see [Cleanup](#Cleanup) for details).                                                                                                                                                                                                                                                                                                                                                                             |
+| auto_cleanup_chunks            | LODOR_AUTO_CLEANUP_CHUNKS    | true            | Defines if Lodor should automatically delete the temporary chunks folder for chunked uploads (see [Cleanup](#Cleanup) for details).                                                                                                                                                                                                                                                                                                                                                                                                      |
+
+### Cleanup
+
+`Lodor` automatically runs a cleanup if the UploadFailed event is triggered after an upload fails or the UploadFinished event is triggered after successful completion.
+In case of a failing upload, all files - chunks and merged - are always forcibly deleted regardless of your configuration settings.
+
+In case of a successfully finished upload, the behavior depends on a number of configuration settings. By default, `Lodor` will delete all existing file chunks during cleanup, but not the merged files in the upload disk.
+ 
+To change this default behavior, you can set `lodor.auto_cleanup_chunks` to `false` to leave the chunks in place after uploading, and `lodor.auto_cleanup` to `true` to always delete the finished uploads once they are completed (as indicated by the `UploadFinished` event).
+
+#### Using auto-cleanup
+
+In a basic setup with no further event listeners registered, Lodor always triggers the `UploadFinished` event once the non-chunked upload succeeded or the chunked upload was successfully merged.
+Therefore, `auto_cleanup` is set to `false` by default. If you set it to `true`, your uploads would otherwise be gone the second they are finished.
+
+If you want to use `auto_cleanup`, you need to make sure that you register a listener for the `FileUploaded` event, usually by adding it to your EventServiceProvider (see [Registering Events & Listeners](https://laravel.com/docs/7.x/events#registering-events-and-listeners) in the Laravel docs for details).
+
+You can simply use Laravel's generator to create a listener class for you, e.g.
+
+``` bash
+artisan make:listener -e "\Cybex\Lodor\Events\FileUploaded" -- FileUploadedListener
+```
+
+Then include it in your EventServiceProvider $listener property:
+
+``` php
+use App\Listeners\FileUploadedListener;
+use Cybex\Lodor\Events\FileUploaded;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        FileUploaded::class => [
+            FileUploadedListener::class,
+        ],
+    ];
+``` 
+
+Inside your `FileUploadedListener` class, you should then process the file as needed in the `handle()` method and trigger the `UploadFinished` event to indicate that you are done processing and the files can be cleaned up:
+
+``` php
+    /**
+     * Handle the event.
+     *
+     * @param  FileUploaded  $event
+     * @return void
+     */
+    public function handle(FileUploaded $event)
+    {
+        $uuid     = $event->uuid;
+        $metadata = $event->metadata;
+
+        // You are also responsible to post updates on the status of the process using Lodor::setUploadStatus()
+        // to keep the frontend up to date on the progress and any info you want to publish along with it.
+        // After the server upload finishes, the upload is put in "waiting" state until the listener(s)
+        // process(es) the upload and set the status to "done" state.
+        Lodor::setUploadStatus($event->uuid,
+            'done',
+            __('Server upload finished.'),
+            __('Upload complete.', ['uuid' => $uuid]),
+            100,
+            $metadata);
+
+        // Then fire the UploadFinished event to signalize that the upload has completed processing.
+        event(new UploadFinished($event->uuid, $event->metadata));
+    }
+``` 
+
+#### Cleaning up manually
+
+You may also choose to keep `auto_cleanup` disabled and do the cleanup yourself. You can do so by following the steps above and add
+
+``` php
+Lodor::cleanupUpload($event->uuid, true);
+```
+
+to your listener's `handle()` method. The second parameter specifies if all files should be forcibly deleted, regardless of the config settings.
+
+#### Caveats
+
+Sometimes, files might not be cleaned up at all, either because the cache info of the upload was deleted, your listener(s) are crashing or if you use queued event listeners and your job queue is failing or not running at all.
+To make sure leftover files are cleaned up, you may want to schedule a cron job that deletes old files from the `lodor_chunked` and `lodor_uploads` storage disks and the according info from the cache periodically.
+In future versions of `Lodor`, it is planned to implement both a Listener and an artisan command to clean up periodically.   
+
 
 ### Testing
 
 ``` bash
 composer test
 ```
+
+### To do
+
+- Cleanup Command for leftover uploads.
 
 ## Contributing
 

--- a/config/lodor.php
+++ b/config/lodor.php
@@ -212,10 +212,25 @@ return [
     |--------------------------------------------------------------------------
     |
     | This setting determines whether Lodor should automatically clean up files
-    | and cache entries after itself.
+    | and cache entries after itself. Note that setting this option to true
+    | will delete your uploaded files immediately after the upload is finished.
+    | You will need to move or otherwise process the file inside a FileUploaded
+    | event listener if you choose to use auto_cleanup.
     |
     */
-    'auto_cleanup' => env('LODOR_AUTO_CLEANUP', true),
+    'auto_cleanup'       => env('LODOR_AUTO_CLEANUP', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Automatic cleanup of temporary chunked files
+    |--------------------------------------------------------------------------
+    |
+    | By default, Lodor automatically cleans up any chunked file directories
+    | after merging. You can prevent this from happening by setting
+    | auto_cleanup_chunks to false.
+    |
+    */
+    'auto_cleanup_chunks' => env('LODOR_AUTO_CLEANUP_CHUNKS', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/EventServiceProvider.php
+++ b/src/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Cybex\Lodor;
 
 use Cybex\Lodor\Events\ChunkedFileUploaded;
+use Cybex\Lodor\Events\UploadFailed;
 use Cybex\Lodor\Events\UploadFinished;
 use Cybex\Lodor\Listeners\CleanupUpload;
 use Cybex\Lodor\Listeners\MergeChunks;
@@ -16,7 +17,10 @@ class EventServiceProvider extends ServiceProvider
         ],
         UploadFinished::class      => [
             CleanupUpload::class,
-        ]
+        ],
+        UploadFailed::class        => [
+            CleanupUpload::class,
+        ],
     ];
 
     /**

--- a/src/Listeners/CleanupUpload.php
+++ b/src/Listeners/CleanupUpload.php
@@ -2,6 +2,7 @@
 
 namespace Cybex\Lodor\Listeners;
 
+use Cybex\Lodor\Events\UploadFailed;
 use Cybex\Lodor\Events\UploadFinished;
 use Cybex\Lodor\LodorFacade as Lodor;
 
@@ -18,14 +19,13 @@ class CleanupUpload
     /**
      * Handle the event.
      *
-     * @param UploadFinished $event
+     * @param UploadFinished|UploadFailed $event
      *
      * @return void
      */
-    public function handle(UploadFinished $event)
+    public function handle($event)
     {
-        if (config('lodor.auto_cleanup', true)) {
-            Lodor::cleanupUpload($event->uuid, $event->metadata['chunked'] ?? null);
-        }
+        // If the listener is triggered by an UploadFailed event, force cleanup.
+        Lodor::cleanupUpload($event->uuid, is_a($event, UploadFailed::class));
     }
 }

--- a/src/Listeners/MergeChunks.php
+++ b/src/Listeners/MergeChunks.php
@@ -71,7 +71,7 @@ class MergeChunks implements ShouldQueue
     /**
      * Handle the event.
      *
-     * @param ChunkedFileUploaded $event
+     * @param ChunkedFileUploaded|null $event
      *
      * @return void
      */

--- a/src/Lodor.php
+++ b/src/Lodor.php
@@ -111,6 +111,7 @@ class Lodor
     public function getUploadStatus(string $uuid): array
     {
         $cachePrefix = config('lodor.cache.upload_status.prefix', 'LODOR_STATUS');
+
         return Cache::get(sprintf('%s_%s', $cachePrefix, $uuid)) ?? [];
     }
 
@@ -132,25 +133,33 @@ class Lodor
         }
 
         $uuidCollection   = collect($uuids);
-        $statusCollection = $uuidCollection->map(function ($uuid) {
-            return $this->getUploadStatus($uuid);
-        })->filter();
+        $statusCollection = $uuidCollection->map(
+            function ($uuid) {
+                return $this->getUploadStatus($uuid);
+            }
+        )->filter();
 
         $totalUploads = $uuidCollection->count();
 
-        $completedUploads = $statusCollection->reduce(function ($carry, $uploadStatus) {
-            return $carry + ($uploadStatus['state'] == 'done' ? 1 : 0);
-        });
+        $completedUploads = $statusCollection->reduce(
+            function ($carry, $uploadStatus) {
+                return $carry + ($uploadStatus['state'] == 'done' ? 1 : 0);
+            }
+        );
 
         $remainingUploads = $totalUploads - $completedUploads;
 
-        $progress = $statusCollection->reduce(function ($carry, $uploadStatus) {
-                return $carry + $uploadStatus['progress'];
-            }) / $totalUploads;
+        $progress = $statusCollection->reduce(
+                function ($carry, $uploadStatus) {
+                    return $carry + $uploadStatus['progress'];
+                }
+            ) / $totalUploads;
 
-        $metadata = $statusCollection->mapWithKeys(function ($status) {
-            return [$status['uuid'] => $status['metadata']];
-        });
+        $metadata = $statusCollection->mapWithKeys(
+            function ($status) {
+                return [$status['uuid'] => $status['metadata']];
+            }
+        );
 
         // If there is only one upload in the uuid list, return the detailed info for this upload.
         // In multi uploads, we only include the generic info below.
@@ -160,11 +169,17 @@ class Lodor
 
         return [
             'state'    => $remainingUploads ? 'processing' : 'done',
-            'status'   => $remainingUploads ? __('Waiting for :remaining_uploads_count uploads to finish processing...',
-                ['remaining_uploads_count' => $remainingUploads]) : __('Processing complete.'),
-            'info'     => $remainingUploads ? __(':remaining_uploads_count of :total_uploads_count files left...',
-                ['remaining_uploads_count' => $remainingUploads, 'total_uploads_count' => $totalUploads]) : __('Completed upload of :total_uploads_count files.',
-                ['total_uploads_count' => $totalUploads]),
+            'status'   => $remainingUploads ? __(
+                'Waiting for :remaining_uploads_count uploads to finish processing...',
+                ['remaining_uploads_count' => $remainingUploads]
+            ) : __('Processing complete.'),
+            'info'     => $remainingUploads ? __(
+                ':remaining_uploads_count of :total_uploads_count files left...',
+                ['remaining_uploads_count' => $remainingUploads, 'total_uploads_count' => $totalUploads]
+            ) : __(
+                'Completed upload of :total_uploads_count files.',
+                ['total_uploads_count' => $totalUploads]
+            ),
             'progress' => $progress,
             'uuids'    => $uuids,
             'metadata' => $metadata,
@@ -198,7 +213,8 @@ class Lodor
     {
         $cacheConfig = config('lodor.cache.upload_status');
 
-        Cache::set(sprintf('%s_%s', $cacheConfig['prefix'] ?? 'LODOR_STATUS', $uuid),
+        Cache::set(
+            sprintf('%s_%s', $cacheConfig['prefix'] ?? 'LODOR_STATUS', $uuid),
             [
                 'state'     => $state,
                 'status'    => $status,
@@ -208,7 +224,8 @@ class Lodor
                 'metadata'  => $metadata,
                 'timestamp' => time(),
             ],
-            $cacheConfig['ttl'] ?? 3600);
+            $cacheConfig['ttl'] ?? 3600
+        );
     }
 
     /**
@@ -292,6 +309,7 @@ class Lodor
     public function setUploadConfig(string $uuid, array $uploadConfig): bool
     {
         $cacheConfig = config('lodor.cache.upload_config');
+
         return Cache::set(sprintf('%s_%s', $cacheConfig['prefix'] ?? 'LODOR', $uuid), $uploadConfig, $cacheConfig['ttl'] ?? 3600);
     }
 
@@ -329,6 +347,7 @@ class Lodor
     {
         $uploadConfig                  = $this->getUploadConfig($uuid);
         $uploadConfig['finalFilename'] = $absoluteDestinationFilename;
+
         return $this->setUploadConfig($uuid, $uploadConfig);
     }
 
@@ -359,8 +378,12 @@ class Lodor
                 if (File::exists($absoluteChunkFilename)) {
                     $chunks[] = $absoluteChunkFilename;
                 } else {
-                    throw new FileNotFoundException(__('Chunk number :chunk_number of :total_chunk_count (:chunk_filename) not found for upload with UUID :uuid.',
-                        ['total_chunk_count' => $chunkCount, 'chunk_number' => $i + 1, 'chunk_filename' => $absoluteChunkFilename, 'uuid' => $uuid]));
+                    throw new FileNotFoundException(
+                        __(
+                            'Chunk number :chunk_number of :total_chunk_count (:chunk_filename) not found for upload with UUID :uuid.',
+                            ['total_chunk_count' => $chunkCount, 'chunk_number' => $i + 1, 'chunk_filename' => $absoluteChunkFilename, 'uuid' => $uuid]
+                        )
+                    );
                 }
             }
         }
@@ -378,51 +401,64 @@ class Lodor
      * @throws UnexpectedValueException
      *
      */
-    public function getUploadDestinationFilename(string $uuid): string
+    public function getUploadDestinationFilename(string $uuid): ?string
     {
-        $uploadConfig = $this->getUploadConfig($uuid);
-
-        if (!array_key_exists('finalFilename', $uploadConfig)) {
-            throw new UnexpectedValueException(__('No file info found in config for upload with UUID :uuid.', ['uuid' => $uuid]));
+        if (!$this->hasUploadConfig($uuid)) {
+            return null;
         }
 
-        return $uploadConfig['finalFilename'];
+        $uploadConfig = $this->getUploadConfig($uuid);
+
+        return $uploadConfig['finalFilename'] ?? null;
     }
 
     /**
      * Removes the upload file(s) for the upload specified by the $uuid.
      * If the optional $isChunked parameter is not specified, we try to
      * determine whether the upload is chunked or not from the config.
+     * If $forceDeleteAll is set, all files will be removed regardless
+     * of the config settings. This is for cleaning up after a failed
+     * upload.
      *
-     * @param string    $uuid
-     *
-     * @param bool|null $isChunked
+     * @param string $uuid
+     * @param bool   $forceDeleteAll
      *
      * @return bool
      */
-    public function removeUploadFiles(string $uuid, bool $isChunked = null): bool
+    public function removeUploadFiles(string $uuid, bool $forceDeleteAll = null): bool
     {
-        $isChunked = $isChunked ?? $this->isChunked($uuid);
-
-        if ($isChunked) {
-            // Chunked: upload is on chunked upload disk in folder <uuid>.$
-            // The whole directory must be deleted.
-            if ($uuid) {
+        if ($uuid) {
+            if ($forceDeleteAll || config('lodor.auto_cleanup_chunks')) {
+                // Remove chunked file if exists.
                 $storageDisk = Storage::disk(Lodor::getChunkedUploadDiskName());
-                try {
-                    $storageDisk->deleteDirectory($uuid);
-                } catch (Exception $e) {
-                    return false;
+
+                // Upload is on chunked upload disk in folder <uuid>.
+                // The whole directory must be deleted.
+                if ($storageDisk->exists($uuid)) {
+                    try {
+                        $storageDisk->deleteDirectory($uuid);
+                    } catch (Exception $e) {
+                        return false;
+                    }
                 }
             }
-        } else {
-            // Not chunked: upload is on single upload disk, file <uuid>.
-            // Single file, no directory removal necessary.
-            $storageDisk = Storage::disk(Lodor::getSingleUploadDiskName());
-            try {
-                $storageDisk->delete($uuid);
-            } catch (Exception $e) {
-                return false;
+
+            // Remove merged or non-chunked upload file.
+            if ($forceDeleteAll || config('lodor.auto_cleanup')) {
+                // Not chunked: upload is on single upload disk, file <uuid>.
+                // Single file, no directory removal necessary.
+                $storageDisk = Storage::disk(Lodor::getSingleUploadDiskName());
+                $filename    = str_replace($storageDisk->path(''), '', $this->getUploadDestinationFilename($uuid) ?? $uuid);
+
+                if ($storageDisk->exists($filename)) {
+                    try {
+                        $storageDisk->delete($filename);
+                    } catch (Exception $e) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
             }
         }
 
@@ -434,11 +470,11 @@ class Lodor
      * We do not remove the upload status cache yet, as it might still be needed for frontend use.
      *
      * @param string    $uuid
-     * @param bool|null $isChunked
+     * @param bool|null $forceDeleteAll
      */
-    public function cleanupUpload(string $uuid, bool $isChunked = null)
+    public function cleanupUpload(string $uuid, bool $forceDeleteAll = null)
     {
-        $this->removeUploadFiles($uuid, $isChunked);
+        $this->removeUploadFiles($uuid, $forceDeleteAll);
         $this->removeUploadConfig($uuid);
     }
 
@@ -453,6 +489,7 @@ class Lodor
     {
         if ($this->hasUploadConfig($uuid)) {
             $config = $this->getUploadConfig($uuid);
+
             return $config['chunked'] ?? false;
         }
 
@@ -474,7 +511,7 @@ class Lodor
      * @param FilesystemAdapter $disk
      * @param string            $relativeFilename
      *
-     * @return string|void
+     * @return string|null
      */
     public function resolveFileExists(FilesystemAdapter $disk, string $relativeFilename): ?string
     {
@@ -515,8 +552,15 @@ class Lodor
      * @return string
      */
     public function getUploadFilename(
-        string $uuid, string $requestFilename, string $originalFilename, string $originalExtension, UploadedFile $file = null, Request $request = null, array $config = null
-    ): string {
+        string $uuid,
+        string $requestFilename,
+        string $originalFilename,
+        string $originalExtension,
+        UploadedFile $file = null,
+        Request $request = null,
+        array $config = null
+    ): string
+    {
         $originalFilename  = $this->cleanFilename($originalFilename);
         $originalExtension = $this->cleanFilename($originalExtension);
         $requestFilename   = $this->cleanFilename($requestFilename);
@@ -579,9 +623,9 @@ class Lodor
      */
     public function finishUpload(string $uploadUuid, array $uploadInfo = [])
     {
-        $state = 'server_upload_done';
-
+        $state        = 'server_upload_done';
         $hasListeners = Event::hasListeners(FileUploaded::class);
+
         if ($hasListeners) {
             $state = 'server_upload_waiting';
         }
@@ -589,6 +633,7 @@ class Lodor
         $this->setUploadState($uploadUuid, $state, ['uuid' => $uploadUuid]);
 
         event(new FileUploaded($uploadUuid, $uploadInfo));
+
         if (!$hasListeners) {
             // No listeners waiting to act on this upload:
             // We are done and can do cleanup.
@@ -655,6 +700,7 @@ class Lodor
             if ($uploaderClass::isChunkedRequest($request)) {
                 return new $uploaderClass($request);
             }
+
             return null;
         }
 
@@ -720,11 +766,13 @@ class Lodor
                 // Destination file already exists: act according to configuration.
                 $destinationFilename = $this->resolveFileExists($completeStorageDisk, $destinationFilename);
                 if ($destinationFilename === null) {
-                    $this->setUploadStatus($uuid,
+                    $this->setUploadStatus(
+                        $uuid,
                         'error',
                         __('Merging chunks...'),
                         __('The destination file :filename already exists.', ['filename' => $destinationFilename]),
-                        100);
+                        100
+                    );
 
                     throw new FileExistsException(__('The destination file :filename already exists.', ['filename' => $destinationFilename]));
                 }
@@ -744,22 +792,28 @@ class Lodor
 
                         stream_copy_to_stream($sourceFileHandle, $destinationFileHandle);
                     } else {
-                        $this->setUploadStatus($uuid,
+                        $this->setUploadStatus(
+                            $uuid,
                             'error',
                             __('Merging chunks...'),
-                            __('Missing chunk :missing_chunk of :total_chunks: expected file :missing_filename',
-                                ['missing_chunk' => $i + 1, 'total_chunks' => $chunkCount, 'missing_filename' => $absoluteChunkFilename]),
-                            100);
+                            __(
+                                'Missing chunk :missing_chunk of :total_chunks: expected file :missing_filename',
+                                ['missing_chunk' => $i + 1, 'total_chunks' => $chunkCount, 'missing_filename' => $absoluteChunkFilename]
+                            ),
+                            100
+                        );
 
                         throw new FileNotFoundException(sprintf('File not found for chunk %d of %d: expected file %s', $i + 1, $chunkCount, $absoluteChunkFilename));
                     }
                 }
             } catch (Exception $e) {
                 // File/disk related error.
-                $this->setUploadStatus($uuid,
+                $this->setUploadStatus(
+                    $uuid,
                     'error',
                     __('Merging chunks...'),
-                    __(':exception_class while merging: :exception_message', ['exception_class' => get_class($e), 'exception_message' => $e->getMessage()], 100));
+                    __(':exception_class while merging: :exception_message', ['exception_class' => get_class($e), 'exception_message' => $e->getMessage()], 100)
+                );
 
                 throw new FileNotFoundException($e);
             } finally {

--- a/src/Lodor.php
+++ b/src/Lodor.php
@@ -445,7 +445,7 @@ class Lodor
 
             // Remove merged or non-chunked upload file.
             if ($forceDeleteAll || config('lodor.auto_cleanup')) {
-                // Not chunked: upload is on single upload disk, file <uuid>.
+                // Not chunked: upload is on single upload disk, filename depending on the config.
                 // Single file, no directory removal necessary.
                 $storageDisk = Storage::disk(Lodor::getSingleUploadDiskName());
                 $filename    = str_replace($storageDisk->path(''), '', $this->getUploadDestinationFilename($uuid) ?? $uuid);

--- a/src/Lodor.php
+++ b/src/Lodor.php
@@ -425,7 +425,7 @@ class Lodor
      *
      * @return bool
      */
-    public function removeUploadFiles(string $uuid, bool $forceDeleteAll = null): bool
+    public function removeUploadFiles(string $uuid, bool $forceDeleteAll = false): bool
     {
         if ($uuid) {
             if ($forceDeleteAll || config('lodor.auto_cleanup_chunks')) {
@@ -469,10 +469,10 @@ class Lodor
      * Cleans up files and configs that are not needed anymore after an upload succeeded or failed.
      * We do not remove the upload status cache yet, as it might still be needed for frontend use.
      *
-     * @param string    $uuid
-     * @param bool|null $forceDeleteAll
+     * @param string $uuid
+     * @param bool   $forceDeleteAll
      */
-    public function cleanupUpload(string $uuid, bool $forceDeleteAll = null)
+    public function cleanupUpload(string $uuid, bool $forceDeleteAll = false)
     {
         $this->removeUploadFiles($uuid, $forceDeleteAll);
         $this->removeUploadConfig($uuid);
@@ -541,13 +541,13 @@ class Lodor
     /**
      * Returns the destination filename of the upload according to the configuration.
      *
-     * @param string       $uuid
-     * @param string       $requestFilename
-     * @param string       $originalFilename
-     * @param string       $originalExtension
-     * @param UploadedFile $file
-     * @param Request|null $request
-     * @param array|null   $config
+     * @param string            $uuid
+     * @param string            $requestFilename
+     * @param string            $originalFilename
+     * @param string            $originalExtension
+     * @param UploadedFile|null $file
+     * @param Request|null      $request
+     * @param array|null        $config
      *
      * @return string
      */


### PR DESCRIPTION
This Pull Request changes the way cleanups are handled by Lodor.
Previously, Lodor would only cleanup file chunks automatically. Now, it takes care of cleaning up all files created during an upload, including the upload itself.

To prevent that users new to Lodor get their uploads deleted before they can get it processed, the default setting for auto_cleanup is now false. Furthermore, the auto_cleanup value is now only responsible for determining if the finished uploads should be deleted or not, leaving the chunk file handling unaffected. The chunk file cleanup got its own configuration setting now (auto_cleanup_chunks), which is true by default, to preserve the expected behavior.

There are breaking changes introduced in this pull request: the removeUploadFiles() and cleanupUploads() methods lost their $isChunked parameter and got a new $forceDeleteAll parameter. Since the parameters are in the same position, manual calls to those methods will delete all files for chunked uploads. It makes no sense to me to keep the $isChunked parameter in place, however, to preserve backwards compatibility, since the package does not seem to be in use by anyone yet, judging by the downloads.