### PR TITLE
Revert phpunit upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 php:
     - 7.2
-    - 7.3.25
-    - 7.4.13
+    - 7.3
+    - 7.4
 
 env:
   matrix:
@@ -15,7 +15,4 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-
-after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+    - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.2
-  - 7.3
-  - 7.4
+    - 7.2
+    - 7.3.25
+    - 7.4.13
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^8.0",
         "sempro/phpunit-pretty-print": "^1.2"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,10 +20,4 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,6 @@
          backupStaticAttributes="false"
          colors="true"
          verbose="true"
-         testdox="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+<phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -12,22 +10,20 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-        <report>
-            <clover outputFile="build/logs/clover.xml"/>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-        </report>
-    </coverage>
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
     <logging>
-        <junit outputFile="build/report.junit.xml"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>

--- a/tests/ChunkUploadTest.php
+++ b/tests/ChunkUploadTest.php
@@ -183,7 +183,7 @@ class ChunkUploadTest extends TestCase
 
         [, $fakeUploadStorage] = $this->uploadChunkedFile('automerge.avi', 5000, 4);
 
-        $this->assertFileDoesNotExist($fakeUploadStorage->path('automerge.avi'), 'The file was merged despite auto_merge_chunks was set to false.');
+        $this->assertFileNotExists($fakeUploadStorage->path('automerge.avi'), 'The file was merged despite auto_merge_chunks was set to false.');
 
         Queue::assertNotPushed(CallQueuedListener::class,
             function ($listener) {
@@ -229,7 +229,7 @@ class ChunkUploadTest extends TestCase
         [$fakeChunkStorage, $fakeUploadStorage, $uploadUuid] = $this->uploadChunkedFile('cleanupvideo.avi', 5000, 4);
 
         $this->assertFileExists($fakeUploadStorage->path('cleanupvideo.avi'), 'The merged file was not found.');
-        $this->assertDirectoryDoesNotExist($fakeChunkStorage->path($uploadUuid), 'The chunks have not been cleaned up.');
+        $this->assertDirectoryNotExists($fakeChunkStorage->path($uploadUuid), 'The chunks have not been cleaned up.');
     }
 
     /**
@@ -243,8 +243,8 @@ class ChunkUploadTest extends TestCase
 
         [$fakeChunkStorage, $fakeUploadStorage, $uploadUuid] = $this->uploadChunkedFile('cleanupvideo.avi', 5000, 4);
 
-        $this->assertFileDoesNotExist($fakeUploadStorage->path('cleanupvideo.avi'), 'The merged file was not cleaned up.');
-        $this->assertDirectoryDoesNotExist($fakeChunkStorage->path($uploadUuid), 'The chunks have not been cleaned up.');
+        $this->assertFileNotExists($fakeUploadStorage->path('cleanupvideo.avi'), 'The merged file was not cleaned up.');
+        $this->assertDirectoryNotExists($fakeChunkStorage->path($uploadUuid), 'The chunks have not been cleaned up.');
     }
 
     /**


### PR DESCRIPTION
This reverts the phpUnit upgrade to version 9, because the upgrade breaks older package configurations.
Therefore, code coverage analysis for php 8.0 won't work until we can upgrade back to phpUnit 9 again.